### PR TITLE
Integrating Voice Consent to Survey Skill template

### DIFF
--- a/survey-skill-template/lambda/custom/languages/de-DE.js
+++ b/survey-skill-template/lambda/custom/languages/de-DE.js
@@ -2,17 +2,20 @@ module.exports = {
   translation: {
     'SKILL_NAME': "tägliches Stand Up",
     'GREETING': [
-      "Velkommen til %s. For at fortsætte skal du sige \"starte mit stand up\".",
+      "Willkommen zu %s. Um fortzufahren, nenne mir bitte deine PIN.",
+    ],
+    'GREETING_PERSONALIZED': [
+      "Velkommen til %s. For at fortsætte skal du sige \"starte mein stand up\".",
     ],
     'GREETING_REPROMPT': [
       "Wie lautet deine PIN?",
     ],
     'PERSONALIZED_GREETING': [
-      "Hej %s",
+      "Hej %s.",
     ],
     'PERSONALIZED_FALLBACK': [
       "Beklager, jeg kan ikke genkende dig. Fortæl mig din adgangskode for at fortsætte.",
-    ],    
+    ],
     'PIN_VALID': [
       "Okay, deine PIN is gültig.",
     ],
@@ -81,5 +84,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "Eine oder mehrere Umgebungsvariablen sind nicht gesetzt. Bitte schaue in die Readme Datei für Hilfe.",
     'ERROR': "Entschuldige, das habe ich nicht verstanden. Kannst du das noch einmal sagen?",
     'ERROR_REPROMPT': "Kannst du das noch einmal sagen?",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+        "Bitte besuchen Sie die App, um Berechtigungen zu erteilen.",
+    ],
+    'VOICE_CONSENT_ERROR_REPROMPT': [
+        "Etwas ist schief gelaufen. Bitte versuchen Sie es später erneut.",
+    ],
   },
 };

--- a/survey-skill-template/lambda/custom/languages/en-AU.js
+++ b/survey-skill-template/lambda/custom/languages/en-AU.js
@@ -2,14 +2,17 @@ module.exports = {
   translation: {
     'SKILL_NAME': "Daily Stand Up",
     'GREETING': [
+      "Welcome to %s. To continue, please tell me your passcode.",
+    ],
+    'GREETING_PERSONALIZED': [
       "Welcome to %s. To continue, please say \"start my stand up\".",
     ],
     'PERSONALIZED_GREETING': [
-      "Hello %s",
+      "Hello %s.",
     ],
     'PERSONALIZED_FALLBACK': [
       "Sorry, I am unable to recognize you. To continue, please tell me your passcode.",
-    ],    
+    ],
     'GREETING_REPROMPT': [
       "What is your passcode?",
     ],
@@ -81,5 +84,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "One or more environment variables is not set. Please see the readme file for help.",
     'ERROR': "Sorry, I didn\'t get that. Could you say that again?",
     'ERROR_REPROMPT': "Could you say that again?",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+        "Please visit the app to grant permissions.",
+    ],
+    'VOICE_CONSENT_ERROR_REPROMPT': [
+        "Something went wrong. Please try again later.",
+    ],
   },
 };

--- a/survey-skill-template/lambda/custom/languages/en-CA.js
+++ b/survey-skill-template/lambda/custom/languages/en-CA.js
@@ -2,14 +2,17 @@ module.exports = {
   translation: {
     'SKILL_NAME': "Daily Stand Up",
     'GREETING': [
+      "Welcome to %s. To continue, please tell me your passcode.",
+    ],
+    'GREETING_PERSONALIZED': [
       "Welcome to %s. To continue, please say \"start my stand up\".",
     ],
     'PERSONALIZED_GREETING': [
-      "Hello %s",
+      "Hello %s.",
     ],
     'PERSONALIZED_FALLBACK': [
       "Sorry, I am unable to recognize you. To continue, please tell me your passcode.",
-    ],    
+    ],
     'GREETING_REPROMPT': [
       "What is your passcode?",
     ],
@@ -81,5 +84,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "One or more environment variables is not set. Please see the readme file for help.",
     'ERROR': "Sorry, I didn\'t get that. Could you say that again?",
     'ERROR_REPROMPT': "Could you say that again?",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+        "Please visit the app to grant permissions.",
+    ],
+    'VOICE_CONSENT_ERROR_REPROMPT': [
+        "Something went wrong. Please try again later.",
+    ],
   },
 };

--- a/survey-skill-template/lambda/custom/languages/en-GB.js
+++ b/survey-skill-template/lambda/custom/languages/en-GB.js
@@ -2,10 +2,13 @@ module.exports = {
   translation: {
     'SKILL_NAME': "Daily Stand Up",
     'GREETING': [
+      "Welcome to %s. To continue, please tell me your passcode.",
+    ],
+    'GREETING_PERSONALIZED': [
       "Welcome to %s. To continue, please say \"start my stand up\".",
     ],
     'PERSONALIZED_GREETING': [
-      "Hello %s",
+      "Hello %s.",
     ],
     'PERSONALIZED_FALLBACK': [
       "Sorry, I am unable to recognize you. To continue, please tell me your passcode.",
@@ -81,5 +84,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "One or more environment variables is not set. Please see the readme file for help.",
     'ERROR': "Sorry, I didn\'t get that. Could you say that again?",
     'ERROR_REPROMPT': "Could you say that again?",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+        "Please visit the app to grant permissions.",
+    ],
+    'VOICE_CONSENT_ERROR_REPROMPT': [
+        "Something went wrong. Please try again later.",
+    ],
   },
 };

--- a/survey-skill-template/lambda/custom/languages/en-IN.js
+++ b/survey-skill-template/lambda/custom/languages/en-IN.js
@@ -2,17 +2,20 @@ module.exports = {
   translation: {
     'SKILL_NAME': "Daily Stand Up",
     'GREETING': [
+      "Welcome to %s. To continue, please tell me your passcode.",
+    ],
+    'GREETING_PERSONALIZED': [
       "Welcome to %s. To continue, please say \"start my stand up\".",
     ],
     'GREETING_REPROMPT': [
       "What is your passcode?",
     ],
     'PERSONALIZED_GREETING': [
-      "Hello %s",
+      "Hello %s.",
     ],
     'PERSONALIZED_FALLBACK': [
       "Sorry, I am unable to recognize you. To continue, please tell me your passcode.",
-    ],    
+    ],
     'PIN_VALID': [
       "Okay, your passcode is valid.",
     ],
@@ -81,5 +84,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "One or more environment variables is not set. Please see the readme file for help.",
     'ERROR': "Sorry, I didn\'t get that. Could you say that again?",
     'ERROR_REPROMPT': "Could you say that again?",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+        "Please visit the app to grant permissions.",
+    ],
+    'VOICE_CONSENT_ERROR_REPROMPT': [
+        "Something went wrong. Please try again later.",
+    ],
   },
 };

--- a/survey-skill-template/lambda/custom/languages/en-US.js
+++ b/survey-skill-template/lambda/custom/languages/en-US.js
@@ -2,7 +2,10 @@ module.exports = {
   translation: {
     'SKILL_NAME': "Daily Stand Up",
     'GREETING': [
-      "Welcome to %s. To continue, please say \"empezar mi stand up\".",
+      "Welcome to %s. To continue, please tell me your passcode.",
+    ],
+    'GREETING_PERSONALIZED': [
+      "Welcome to %s. To continue, please say \"start my stand up\".",
     ],
     'PERSONALIZED_GREETING': [
       "Hello %s",
@@ -81,5 +84,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "One or more environment variables is not set. Please see the readme file for help.",
     'ERROR': "Sorry, I didn\'t get that. Could you say that again?",
     'ERROR_REPROMPT': "Could you say that again?",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+        "Please visit the app to grant permissions.",
+    ],
+    'VOICE_CONSENT_ERROR_REPROMPT': [
+        "Something went wrong. Please try again later.",
+    ],
   },
 };

--- a/survey-skill-template/lambda/custom/languages/es-ES.js
+++ b/survey-skill-template/lambda/custom/languages/es-ES.js
@@ -2,13 +2,16 @@ module.exports = {
   translation: {
     'SKILL_NAME': "Daily Stand Up",
     'GREETING': [
-      "Bienvenido a% s. Para continuar, diga \"empezar mi stand up\"",
+      "Bienvenido a %s. Para continuar, por favor dime tu pin.",
+    ],
+    'GREETING_PERSONALIZED': [
+      "Bienvenido a %s. Para continuar, diga \"comienza mi stand up\"",
     ],
     'GREETING_REPROMPT': [
       "¿Cuál es tu pin?",
     ],
     'PERSONALIZED_GREETING': [
-      "Hola %s",
+      "Hola %s.",
     ],
     'PERSONALIZED_FALLBACK': [
       "Lo siento, no puedo reconocerte. Para continuar, dígame su contraseña.",
@@ -81,5 +84,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "No se establece una o más variables de entorno. Consulta el archivo Léame para obtener ayuda.",
     'ERROR': "Lo siento, no entendí eso. ¿Podrías repetir lo que dijiste?",
     'ERROR_REPROMPT': "¿Podrías repetir lo que dijiste?",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+        "Visite la aplicación para otorgar permisos.",
+    ],
+    'VOICE_CONSENT_ERROR_REPROMPT': [
+        "Algo salió mal. Por favor, inténtelo de nuevo más tarde.",
+    ],
   },
 };

--- a/survey-skill-template/lambda/custom/languages/es-MX.js
+++ b/survey-skill-template/lambda/custom/languages/es-MX.js
@@ -2,13 +2,16 @@ module.exports = {
   translation: {
     'SKILL_NAME': "Daily Stand Up",
     'GREETING': [
-      "Bienvenido a% s. Para continuar, diga \"empezar mi stand up\"",
+      "Bienvenido a %s. Para continuar, por favor dime tu pin.",
+    ],
+    'GREETING_PERSONALIZED': [
+      "Bienvenido a %s. Para continuar, diga \"comienza mi stand up\"",
     ],
     'GREETING_REPROMPT': [
       "¿Cuál es tu pin?",
     ],
     'PERSONALIZED_GREETING': [
-      "Hola %s",
+      "Hola %s.",
     ],
     'PERSONALIZED_FALLBACK': [
       "Lo siento, no puedo reconocerte. Para continuar, dígame su contraseña.",
@@ -81,5 +84,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "No se establece una o más variables de entorno. Consulta el archivo Léame para obtener ayuda.",
     'ERROR': "Lo siento, no entendí eso. ¿Podrías repetir lo que dijiste?",
     'ERROR_REPROMPT': "¿Podrías repetir lo que dijiste?",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+        "Visite la aplicación para otorgar permisos.",
+    ],
+    'VOICE_CONSENT_ERROR_REPROMPT': [
+        "Algo salió mal. Por favor, inténtelo de nuevo más tarde.",
+    ],
   },
 };

--- a/survey-skill-template/lambda/custom/languages/es-US.js
+++ b/survey-skill-template/lambda/custom/languages/es-US.js
@@ -2,13 +2,16 @@ module.exports = {
   translation: {
     'SKILL_NAME': "Daily Stand Up",
     'GREETING': [
-      "Bienvenido a% s. Para continuar, diga \"empezar mi stand up\"",
+      "Bienvenido a %s. Para continuar, por favor dime tu pin.",
+    ],
+    'GREETING_PERSONALIZED': [
+      "Bienvenido a %s. Para continuar, diga \"comienza mi stand up\"",
     ],
     'GREETING_REPROMPT': [
       "¿Cuál es tu pin?",
     ],
     'PERSONALIZED_GREETING': [
-      "Hola %s",
+      "Hola %s.",
     ],
     'PERSONALIZED_FALLBACK': [
       "Lo siento, no puedo reconocerte. Para continuar, dígame su contraseña.",
@@ -81,5 +84,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "No se establece una o más variables de entorno. Consulta el archivo Léame para obtener ayuda.",
     'ERROR': "Lo siento, no entendí eso. ¿Podrías repetir lo que dijiste?",
     'ERROR_REPROMPT': "¿Podrías repetir lo que dijiste?",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+        "Visite la aplicación para otorgar permisos.",
+    ],
+    'VOICE_CONSENT_ERROR_REPROMPT': [
+        "Algo salió mal. Por favor, inténtelo de nuevo más tarde.",
+    ],
   },
 };

--- a/survey-skill-template/lambda/custom/languages/fr-CA.js
+++ b/survey-skill-template/lambda/custom/languages/fr-CA.js
@@ -2,17 +2,20 @@ module.exports = {
   translation: {
     'SKILL_NAME': "Stand Up Quotidien",
     'GREETING': [
+      "Bienvenue à %s. Pour continuer, veuillez me dire votre pin.",
+    ],
+    'GREETING_PERSONALIZED': [
       "Bienvenue à %s. Pour continuer, dites \"commencer mon stand up\".",
     ],
     'GREETING_REPROMPT': [
       "Quel est votre pin ?",
     ],
     'PERSONALIZED_GREETING': [
-      "Bonjour %s",
+      "Bonjour %s.",
     ],
     'PERSONALIZED_FALLBACK': [
       "Désolé, je ne peux pas vous reconnaître. Pour continuer, veuillez m'indiquer votre mot de passe.",
-    ],       
+    ],
     'PIN_VALID': [
       "Ok,votre pin est valid.",
     ],
@@ -81,5 +84,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "Une ou plusieurs variables d'environnement ne sont pas fixées. Veuillez consulter le fichier readme pour obtenir de l'aide.",
     'ERROR': "Désolé, je n'ai pas compris. Pouvez vous répéter ?",
     'ERROR_REPROMPT': "Pouvez-vous répéter ?",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+      "Veuillez visiter l'application pour accorder des autorisations.",
+    ],
+    'VOICE_CONSENT_ERROR_REPROMPT': [
+      "Quelque chose s'est mal passé. Veuillez réessayer plus tard.",
+    ],
   },
 };

--- a/survey-skill-template/lambda/custom/languages/fr-FR.js
+++ b/survey-skill-template/lambda/custom/languages/fr-FR.js
@@ -2,17 +2,20 @@ module.exports = {
   translation: {
     'SKILL_NAME': "Stand Up Quotidien",
     'GREETING': [
+      "Bienvenue à %s. Pour continuer, veuillez me dire votre pin.",
+    ],
+    'GREETING_PERSONALIZED': [
       "Bienvenue à %s. Pour continuer, dites \"commencer mon stand up\".",
     ],
     'GREETING_REPROMPT': [
       "Quel est votre pin ?",
     ],
     'PERSONALIZED_GREETING': [
-      "Bonjour %s",
+      "Bonjour %s.",
     ],
     'PERSONALIZED_FALLBACK': [
       "Désolé, je ne peux pas vous reconnaître. Pour continuer, veuillez m'indiquer votre mot de passe.",
-    ], 
+    ],
     'PIN_VALID': [
       "Ok,votre pin est valid.",
     ],
@@ -81,5 +84,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "Une ou plusieurs variables d'environnement ne sont pas fixées. Veuillez consulter le fichier readme pour obtenir de l'aide.",
     'ERROR': "Désolé, je n'ai pas compris. Pouvez vous répéter ?",
     'ERROR_REPROMPT': "Pouvez-vous répéter ?",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+        "Veuillez visiter l'application pour accorder des autorisations.",
+    ],
+    'VOICE_CONSENT_ERROR_REPROMPT': [
+        "Quelque chose s'est mal passé. Veuillez réessayer plus tard.",
+    ],
   },
 };

--- a/survey-skill-template/lambda/custom/languages/hi-IN.js
+++ b/survey-skill-template/lambda/custom/languages/hi-IN.js
@@ -3,17 +3,20 @@ module.exports = {
   translation: {
     'SKILL_NAME': "Daily Stand Up",
     'GREETING': [
+      "%s में स्वागत है। जारी रखने के लिए, कृपया मुझे अपना pin  बताएं।",
+    ],
+    'GREETING_PERSONALIZED': [
       "%s में आपका स्वागत है। जारी रखने के लिए, कृपया कहें \"मेरा स्टैंड अप शुरू करो\".",
     ],
     'GREETING_REPROMPT': [
       "तुम्हारा pin  क्या है?",
     ],
     'PERSONALIZED_GREETING': [
-      "नमस्ते %s",
+      "नमस्ते %s।",
     ],
     'PERSONALIZED_FALLBACK': [
       "क्षमा करें, मैं आपको पहचानने में असमर्थ हूँ। जारी रखने के लिए, कृपया मुझे अपना पासकोड बताएं।",
-    ], 
+    ],
     'PIN_VALID': [
       "ठीक है, आपका pin मान्य है।",
     ],
@@ -82,5 +85,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "एक या अधिक environment variable set नहीं है। कृपया मदद के लिए readme file देखें।",
     'ERROR': "क्षमा करें, मुझे वह नहीं मिला। क्या आप यह फिर से कह सकते हैं?",
     'ERROR_REPROMPT': "क्या आप यह फिर से कह सकते हैं?",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+       "अनुमति देने के लिए कृपया ऐप पर जाएं।",
+     ],
+     'VOICE_CONSENT_ERROR_REPROMPT': [
+       "कुछ गलत हो गया। बाद में पुन: प्रयास करें।",
+     ],
   },
 };

--- a/survey-skill-template/lambda/custom/languages/it-IT.js
+++ b/survey-skill-template/lambda/custom/languages/it-IT.js
@@ -3,17 +3,20 @@ module.exports = {
   translation: {
     'SKILL_NAME': "Stand Up quotidiano",
     'GREETING': [
-      "Benvenuto in %s. Per continuare, per favore dì \"inizia il mio alzarsi\".",
+      "Benvenuto in %s. Per continuare, per favore dammi il tuo codice pin",
+    ],
+    'GREETING_PERSONALIZED': [
+      "Benvenuto in %s. Per continuare, per favore dì \"Inizia il mio stand up\".",
     ],
     'GREETING_REPROMPT': [
       "Qual è il tuo codice pin?",
     ],
     'PERSONALIZED_GREETING': [
-      "Ciao %s",
+      "Ciao %s.",
     ],
     'PERSONALIZED_FALLBACK': [
       "Mi dispiace, non riesco a riconoscerti. Per continuare, dimmi il tuo passcode.",
-    ], 
+    ],
     'PIN_VALID': [
       "Ok, il tuo codice pin è valido.",
     ],
@@ -82,5 +85,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "Una o più variabili di ambiente non sono impostate. Per ulteriori informazioni, consulta il file readme.",
     'ERROR': "Scusami, non ho capito. Puoi ripetere? ",
     'ERROR_REPROMPT': "Puoi ripetere?",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+        "Visita l'app per concedere le autorizzazioni.",
+    ],
+    'VOICE_CONSENT_ERROR_REPROMPT': [
+        "Qualcosa è andato storto. Per favore riprova più tardi.",
+    ],
   },
 };

--- a/survey-skill-template/lambda/custom/languages/ja-JP.js
+++ b/survey-skill-template/lambda/custom/languages/ja-JP.js
@@ -3,17 +3,20 @@ module.exports = {
   translation: {
     'SKILL_NAME': "デイリースタンドアップ",
     'GREETING': [
+      "%s へようこそ。アンショウバンゴウを教えてください",
+    ],
+    'GREETING_PERSONALIZED': [
       "％s へようこそ。続行するには, please say \"私のスタンドアップを開始します\".",
     ],
     'GREETING_REPROMPT': [
       "アンショウバンゴウを教えてください",
     ],
     'PERSONALIZED_GREETING': [
-      "こんにちは %s",
+      "こんにちは %s.",
     ],
     'PERSONALIZED_FALLBACK': [
       "申し訳ありませんが、あなたを認識できません。続行するには、パスコードを教えてください",
-    ], 
+    ],
     'PIN_VALID': [
       "アンショウバンゴウは有効です。",
     ],
@@ -82,5 +85,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "いくつかの環境変数が正しく設定されていません。リードミーファイルに記載されているヘルプを参照してください。",
     'ERROR': "聞き取れませんでした。もう一度お願いします。",
     'ERROR_REPROMPT': "もう一度お願いします。",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+        "アプリにアクセスして権限を付与してください。",
+    ],
+    'VOICE_CONSENT_ERROR_REPROMPT': [
+        "何かがうまくいかなかった。後でもう一度やり直してください。",
+    ],
   },
 };

--- a/survey-skill-template/lambda/custom/languages/pt-BR.js
+++ b/survey-skill-template/lambda/custom/languages/pt-BR.js
@@ -3,17 +3,20 @@ module.exports = {
   translation: {
     'SKILL_NAME': "Stand Up Diário",
     'GREETING': [
-      "Bem-vindo a% s. Para continuar, por favor diga \"comece minha postura\".",
+      "Boas vindas ao %s. Para continuar, por favor forneça sua senha.",
+    ],
+    'GREETING_PERSONALIZED': [
+      "Bem-vindo ao %s. Para continuar, por favor diga \"inicie meu stand up\".",
     ],
     'GREETING_REPROMPT': [
       "Qual é a sua senha?",
     ],
     'PERSONALIZED_GREETING': [
-      "Olá %s",
+      "Olá %s.",
     ],
     'PERSONALIZED_FALLBACK': [
       "Desculpe, não consigo reconhecê-lo. Para continuar, diga-me sua senha.",
-    ], 
+    ],
     'PIN_VALID': [
       "Ok, sua senha é válida",
     ],
@@ -82,5 +85,11 @@ module.exports = {
     'ENV_NOT_CONFIGURED': "Uma ou mais configurações não estão ajustadas. Por favor leia o arquivo readme para ajuda.",
     'ERROR': "Desculpe, eu não entendi. Você poderia repetir?",
     'ERROR_REPROMPT': "Você poderia repetir?",
+    'VOICE_CONSENT_DENIED_REPROMPT': [
+        "Visite o aplicativo para conceder permissões.",
+    ],
+    'VOICE_CONSENT_ERROR_REPROMPT': [
+        "Algo deu errado. Por favor, tente novamente mais tarde.",
+    ],
   },
 };

--- a/survey-skill-template/lambda/custom/voiceConsentUtil.js
+++ b/survey-skill-template/lambda/custom/voiceConsentUtil.js
@@ -1,0 +1,156 @@
+ /**
+  * This is the library that handles
+  * - Making a call to voice consent skill based on the inputs passed
+  * - Handle callbacks from voice consent
+  *
+  * Developer README:
+  * 1) Make a call to the library as follows....to initiate a voice consent request
+  *      voiceConsentUtil.getVoiceConsentPermissionRequest(handlerInput, Array<RequestedPermission>).getResponse();
+  *
+  * 2) Add the handler in your respective chain to handle the skill connection response
+  exports.handler = Alexa.SkillBuilders.custom()
+  .addRequestHandlers(
+  ......
+  //handler that handles skill response for voice consent
+  new voiceConsentUtil.skillConnectionsResponseHandler(handleCallBackForVoiceConsentAccepted)
+  ....
+  )
+
+  where handleCallBackForVoiceConsentAccepted is a function that domain specific logic when the request has been accepted
+  Ex:
+  async function handleCallBackForVoiceConsentAccepted(handlerInput) {
+             ...your code to handle goes here....
+         }
+  }
+  *
+  * */
+
+  'use strict';
+  const Alexa = require('ask-sdk-core');
+
+
+  /**
+   * Consent type determining the level at which user gives access to the permissions
+   * @type {Readonly<{ACCOUNT: string, PERSON: string}>}
+   */
+  const CONSENT_LEVEL = Object.freeze({
+      PERSON : "PERSON",
+      ACCOUNT: "ACCOUNT"
+  });
+
+
+  /**
+   * Util class to hold the requested permission data.
+   * @param permissionScope - string of permission scope name.
+   * @param consentLevel - string of consent level.
+   */
+  class RequestedPermission {
+      constructor(permissionScope, consentLevel) {
+          this.permissionScope = permissionScope;
+          this.consentLevel = consentLevel;
+      }
+  }
+
+
+  /**
+   * Function that handles sending voice consent request for respective params
+   * @params handlerInput - the handlerInput received from the IntentRequest
+   * @params permissionScope - the scope to which voice permission needs to be requested
+   * @params consentLevel - the consent level to which voice permission needs to be requested
+   *
+   * @returns AskForPermissionsConsentRequest request
+   **/
+  const getVoiceConsentPermissionRequest = (handlerInput, requestedPermissions) => {
+      console.log("requestedPermissions", requestedPermissions);
+      let permissionScopes = [];
+      requestedPermissions.forEach(element => {
+          permissionScopes.push({
+              "permissionScope": element.permissionScope,
+              "consentLevel": element.consentLevel,
+          })
+      });
+      return handlerInput.responseBuilder
+          .addDirective({
+              type: "Connections.StartConnection",
+              uri: "connection://AMAZON.AskForPermissionsConsent/2",
+              input: {
+                  "@type": "AskForPermissionsConsentRequest",
+                  "@version": "2",
+                  "permissionScopes": permissionScopes
+              },
+              token: ""
+          });
+  }
+
+
+  /**
+   * Default function to handle the case where the customer has rejected the consent via voice
+   * Note: Developers can choose to override this behaviour by defining their own call back function to handle rejected case.
+   *
+   * @params handlerInput - the handlerInput received from the IntentRequest
+   * @returns Response with rejected content
+   **/
+  const handleCallBackForVoiceConsentRejected = (handlerInput) => {
+      const requestAttributes = handlerInput.attributesManager.getRequestAttributes();
+      ///DENIED handling of connections response
+      return handlerInput.responseBuilder
+          .speak(requestAttributes.t('VOICE_CONSENT_DENIED_REPROMPT'))
+          .getResponse();
+  }
+
+
+  /**
+   * Function to render default error message
+   *
+   * @params handlerInput - the handlerInput received from the IntentRequest
+   * @returns Response with error message
+   **/
+  const defaultErrorResponse = (handlerInput) => {
+      const requestAttributes = handlerInput.attributesManager.getRequestAttributes();
+      return handlerInput.responseBuilder
+          .speak(requestAttributes.t('VOICE_CONSENT_ERROR_REPROMPT'))
+          .getResponse();
+  }
+
+  /**
+   * Response handler that handles SessionResumedRequest response from VoiceConsentSkill
+   */
+  const SessionResumedRequestHandler = class {
+
+      constructor(callBackForAccepted,callBackForRejected = handleCallBackForVoiceConsentRejected) {
+          this.callBackForAccepted = callBackForAccepted
+          this.callBackForRejected = callBackForRejected
+      }
+
+      canHandle(handlerInput) {
+          return Alexa.getRequestType(handlerInput.requestEnvelope) === 'SessionResumedRequest';
+      }
+
+      handle(handlerInput) {
+          const result = handlerInput.requestEnvelope.request.cause.result;
+          if (typeof result !== 'undefined') {
+              switch (result.status) {
+                  case 'ACCEPTED' :
+                      return this.callBackForAccepted(handlerInput);
+                  case 'DENIED' :
+                      return this.callBackForRejected(handlerInput);
+                  case 'REDIRECT_TO_APP':
+                      return this.callBackForRejected(handlerInput);
+                  default :
+                      ///Default handling of connections response
+                      // Developer can override by having a different callback/ plain function to render different message
+                      return defaultErrorResponse(handlerInput);
+              }
+          }
+          ///Unknown error handling
+          return defaultErrorResponse(handlerInput);
+      }
+  }
+
+  //make these modules available to index.js
+  module.exports = {
+      getVoiceConsentPermissionRequest,
+      SessionResumedRequestHandler,
+      CONSENT_LEVEL,
+      RequestedPermission
+  };

--- a/survey-skill-template/models/de-DE.json
+++ b/survey-skill-template/models/de-DE.json
@@ -29,7 +29,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -67,8 +67,7 @@
                         "{questionToday} heute",
                         "{questionYesterday} gestern",
                         "gestern {questionYesterday}",
-                        "heute {questionToday}",
-                        "starte mein Stand Up"
+                        "heute {questionToday}"
                     ]
                 },
                 {
@@ -92,6 +91,13 @@
                         "wie bekomme ich eine PIN",
                         "ich brauche eine neue PIN",
                         "ich habe meine PIN vergessen"
+                    ]
+                },
+                {
+                    "name": "StartMyStandupIntent",
+                    "slots": [],
+                    "samples": [
+                        "starte mein stand up"
                     ]
                 }
             ],

--- a/survey-skill-template/models/en-AU.json
+++ b/survey-skill-template/models/en-AU.json
@@ -29,7 +29,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -67,8 +67,7 @@
                         "{questionToday} today",
                         "{questionYesterday} yesterday",
                         "yesterday {questionYesterday}",
-                        "today {questionToday}",
-                        "start my stand up"
+                        "today {questionToday}"
                     ]
                 },
                 {
@@ -92,6 +91,13 @@
                         "how do i get a pin",
                         "i need a new pin",
                         "i forgot my pin"
+                    ]
+                },
+                {
+                    "name": "StartMyStandupIntent",
+                    "slots": [],
+                    "samples": [
+                        "start my stand up"
                     ]
                 }
             ],

--- a/survey-skill-template/models/en-CA.json
+++ b/survey-skill-template/models/en-CA.json
@@ -29,7 +29,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -67,8 +67,7 @@
                         "{questionToday} today",
                         "{questionYesterday} yesterday",
                         "yesterday {questionYesterday}",
-                        "today {questionToday}",
-                        "start my stand up"
+                        "today {questionToday}"
                     ]
                 },
                 {
@@ -92,6 +91,13 @@
                         "how do i get a pin",
                         "i need a new pin",
                         "i forgot my pin"
+                    ]
+                },
+                {
+                    "name": "StartMyStandupIntent",
+                    "slots": [],
+                    "samples": [
+                        "start my stand up"
                     ]
                 }
             ],

--- a/survey-skill-template/models/en-GB.json
+++ b/survey-skill-template/models/en-GB.json
@@ -29,7 +29,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -67,8 +67,7 @@
                         "{questionToday} today",
                         "{questionYesterday} yesterday",
                         "yesterday {questionYesterday}",
-                        "today {questionToday}",
-                        "start my stand up"
+                        "today {questionToday}"
                     ]
                 },
                 {

--- a/survey-skill-template/models/en-IN.json
+++ b/survey-skill-template/models/en-IN.json
@@ -29,7 +29,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -67,8 +67,7 @@
                         "{questionToday} today",
                         "{questionYesterday} yesterday",
                         "yesterday {questionYesterday}",
-                        "today {questionToday}",
-                        "start my stand up"
+                        "today {questionToday}"
                     ]
                 },
                 {
@@ -92,6 +91,13 @@
                         "how do i get a pin",
                         "i need a new pin",
                         "i forgot my pin"
+                    ]
+                },
+                {
+                    "name": "StartMyStandupIntent",
+                    "slots": [],
+                    "samples": [
+                        "start my stand up"
                     ]
                 }
             ],

--- a/survey-skill-template/models/en-US.json
+++ b/survey-skill-template/models/en-US.json
@@ -29,7 +29,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -67,8 +67,7 @@
                         "{questionToday} today",
                         "{questionYesterday} yesterday",
                         "yesterday {questionYesterday}",
-                        "today {questionToday}",
-                        "start my stand up"
+                        "today {questionToday}"
                     ]
                 },
                 {

--- a/survey-skill-template/models/es-ES.json
+++ b/survey-skill-template/models/es-ES.json
@@ -24,7 +24,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -62,8 +62,7 @@
                         "{questionToday} hoy",
                         "{questionYesterday} ayer",
                         "ayer {questionYesterday}",
-                        "hoy {questionToday}",
-                        "comienza mi stand up"
+                        "hoy {questionToday}"
                     ]
                 },
                 {
@@ -87,6 +86,13 @@
                         "cómo consigo un pin",
                         "necesito un nuevo pin",
                         "olvidé mi pin"
+                    ]
+                },
+                {
+                    "name": "StartMyStandupIntent",
+                    "slots": [],
+                    "samples": [
+                        "comienza mi stand up"
                     ]
                 }
             ],

--- a/survey-skill-template/models/es-MX.json
+++ b/survey-skill-template/models/es-MX.json
@@ -24,7 +24,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -62,8 +62,7 @@
                         "{questionToday} hoy",
                         "{questionYesterday} ayer",
                         "ayer {questionYesterday}",
-                        "hoy {questionToday}",
-                        "comienza mi stand up"
+                        "hoy {questionToday}"
                     ]
                 },
                 {
@@ -87,6 +86,13 @@
                         "cómo consigo un pin",
                         "necesito un nuevo pin",
                         "olvidé mi pin"
+                    ]
+                },
+                {
+                    "name": "StartMyStandupIntent",
+                    "slots": [],
+                    "samples": [
+                        "comienza mi stand up"
                     ]
                 }
             ],

--- a/survey-skill-template/models/es-US.json
+++ b/survey-skill-template/models/es-US.json
@@ -24,7 +24,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -62,8 +62,7 @@
                         "{questionToday} hoy",
                         "{questionYesterday} ayer",
                         "ayer {questionYesterday}",
-                        "hoy {questionToday}",
-                        "comienza mi stand up"
+                        "hoy {questionToday}"
                     ]
                 },
                 {
@@ -87,6 +86,13 @@
                         "cómo consigo un pin",
                         "necesito un nuevo pin",
                         "olvidé mi pin"
+                    ]
+                },
+                {
+                    "name": "StartMyStandupIntent",
+                    "slots": [],
+                    "samples": [
+                        "comienza mi stand up"
                     ]
                 }
             ],

--- a/survey-skill-template/models/fr-CA.json
+++ b/survey-skill-template/models/fr-CA.json
@@ -24,7 +24,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -62,8 +62,7 @@
                         "{questionToday} aujourd'hui",
                         "{questionYesterday} hier",
                         "hier {questionYesterday}",
-                        "aujourd'hui {questionToday}",
-                        "commencer mon stand up"
+                        "aujourd'hui {questionToday}"
                     ]
                 },
                 {
@@ -87,6 +86,13 @@
                         "comment obtenir un pin",
                         "J'ai besoin d'un nouveau pin",
                         "j'ai oublié mon pin"
+                    ]
+                },
+                {
+                    "name": "StartMyStandupIntent",
+                    "slots": [],
+                    "samples": [
+                        "commencer mon stand up"
                     ]
                 }
             ],

--- a/survey-skill-template/models/fr-FR.json
+++ b/survey-skill-template/models/fr-FR.json
@@ -24,7 +24,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -62,8 +62,7 @@
                         "{questionToday} aujourd'hui",
                         "{questionYesterday} hier",
                         "hier {questionYesterday}",
-                        "aujourd'hui {questionToday}",
-                        "commencer mon stand up"
+                        "aujourd'hui {questionToday}"
                     ]
                 },
                 {
@@ -87,6 +86,13 @@
                         "comment obtenir un pin.",
                         "J'ai besoin d'un nouveau pin",
                         "j'ai oublié mon pin"
+                    ]
+                },
+                {
+                    "name": "StartMyStandupIntent",
+                    "slots": [],
+                    "samples": [
+                        "commencer mon stand up"
                     ]
                 }
             ],

--- a/survey-skill-template/models/hi-IN.json
+++ b/survey-skill-template/models/hi-IN.json
@@ -24,7 +24,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -62,8 +62,7 @@
                         "{questionToday} आज",
                         "{questionYesterday} कल",
                         "कल {questionYesterday}",
-                        "आज {questionToday}",
-                        "मेरा stand up  शुरू करो"
+                        "आज {questionToday}"
                     ]
                 },
                 {
@@ -87,6 +86,13 @@
                         "मुझे pin  कैसे मिलेगा",
                         "मुझे एक नया pin  चाहिए",
                         "मैं अपना pin  भूल गया"
+                    ]
+                },
+                {
+                    "name": "StartMyStandupIntent",
+                    "slots": [],
+                    "samples": [
+                        "मेरा stand up शुरू करो"
                     ]
                 }
             ],

--- a/survey-skill-template/models/it-IT.json
+++ b/survey-skill-template/models/it-IT.json
@@ -24,7 +24,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -62,8 +62,7 @@
                         "{questionToday} oggi",
                         "{questionYesterday} ieri",
                         "ieri {questionYesterday} ",
-                        "oggi {questionToday} ",
-                        "Inizia il mio stand up"
+                        "oggi {questionToday} "
                     ]
                 },
                 {
@@ -83,6 +82,13 @@
                         "Come posso ottenere un codice pin",
                         "Ho bisogno di un codice pin nuovo",
                         "Ho dimenticato il mio codice pin"
+                    ]
+                },
+                {
+                    "name": "StartMyStandupIntent",
+                    "slots": [],
+                    "samples": [
+                        "Inizia il mio stand up"
                     ]
                 }
             ],

--- a/survey-skill-template/models/ja-JP.json
+++ b/survey-skill-template/models/ja-JP.json
@@ -24,7 +24,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -62,8 +62,7 @@
                         "今日の {questionToday}",
                         "昨日の {questionYesterday}",
                         "昨日の {questionToday}",
-                        "今日の {questionYesterday}",
-                        "スタンドアップを開始する"
+                        "今日の {questionYesterday}"
                     ]
                 },
                 {
@@ -87,6 +86,13 @@
                         "ピンコードはどうやって取得しますか",
                         "新しいピンコードをください",
                         "ピンコードを忘れました"
+                    ]
+                },
+                {
+                    "name": "StartMyStandupIntent",
+                    "slots": [],
+                    "samples": [
+                        "私のスタンドアップを開始します"
                     ]
                 }
             ],

--- a/survey-skill-template/models/pt-BR.json
+++ b/survey-skill-template/models/pt-BR.json
@@ -24,7 +24,7 @@
                     "slots": [
                         {
                             "name": "MeetingCode",
-                            "type": "AMAZON.FOUR_DIGIT_NUMBER"
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -62,8 +62,7 @@
                         "{questionToday} hoje",
                         "{questionYesterday} ontem",
                         "ontem {questionYesterday}",
-                        "hoje {questionToday}",
-                        "inicie meu stand up"
+                        "hoje {questionToday}"
                     ]
                 },
                 {
@@ -87,6 +86,13 @@
                         "como consigo uma senha",
                         "eu preciso de uma senha",
                         "esqueci minha senha"
+                    ]
+                },
+                {
+                    "name": "StartMyStandupIntent",
+                    "slots": [],
+                    "samples": [
+                        "inicie meu stand up"
                     ]
                 }
             ],

--- a/survey-skill-template/skill.json
+++ b/survey-skill-template/skill.json
@@ -8,7 +8,7 @@
         },
         "permissions": [
             {
-                "name": "alexa::profile:name:read"
+                "name": "alexa::profile:given_name:read"
             },
             {
                 "name": "alexa::profile:email:read"


### PR DESCRIPTION
- Handling voice consent scenarios when user has not given permissions for given_name/email in the alexa app.
- Added personalization intent handler (start my stand up) for all other languages. It was previously only working for en-US.
- Changed meeting code from AMAZON.FOUR_DIGIT_NUMBER to AMAZON.NUMBER because we expect user pins to be 6- digit numbers. It was working fine with FOUR_DIGIT_NUMBER for English and Spanish but was having issues in Hindi, Portuguese and Italian.